### PR TITLE
Add support for configuration via a query

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This file will be the only entry point for Karma:
 #### karma.conf.js
 
 ```js
+var babelPresets = ['es2015', 'stage-0', 'react'];
+
 config.set({
     …
     files: [
@@ -67,19 +69,6 @@ config.set({
         'test/index.js': 'webpack'
     },
     webpack: {
-        // *optional* babel options: isparta will use it as well as babel-loader
-        babel: {
-            presets: ['es2015', 'stage-0', 'react']
-        },
-        // *optional* isparta options: istanbul behind isparta will use it
-        isparta: {
-            embedSource: true,
-            noAutoWrap: true,
-            // these babel options will be passed only to isparta and not to babel-loader
-            babel: {
-                presets: ['es2015', 'stage-0', 'react']
-            }
-        },
         …
         module: {
             preLoaders: [
@@ -90,13 +79,23 @@ config.set({
                         path.resolve('src/components/'),
                         path.resolve('node_modules/')
                     ],
-                    loader: 'babel'
+                    loader: 'babel',
+                    query: babelPresets
                 },
                 // transpile and instrument only testing sources with isparta
                 {
                     test: /\.js$/,
                     include: path.resolve('src/components/'),
-                    loader: 'isparta'
+                    loader: 'isparta',
+                    // *optional* isparta options: istanbul behind isparta will use it
+                    query: {
+                        embedSource: true,
+                        noAutoWrap: true,
+                        // these babel options will be passed only to isparta and not to babel-loader
+                        babel: {
+                            presets: babelPresets
+                        }
+                    }
                 }
             ]
         }

--- a/index.js
+++ b/index.js
@@ -1,13 +1,16 @@
 'use strict';
 
 var isparta = require('isparta');
+var loaderUtils = require('loader-utils');
 
 module.exports = function(source) {
-    var config = this.options.isparta || {
+    var query = loaderUtils.parseQuery(this.query);
+    var defaultConfig = {
         embedSource: true,
         noAutoWrap: true,
         babel: this.options.babel
     };
+    var config = Object.assign({}, defaultConfig, this.options.isparta, query);
 
     var instrumenter = new isparta.Instrumenter(config);
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,21 @@
 {
   "name": "isparta-loader",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "isparta instrumenter loader for webpack",
-  "keywords": [ "webpack", "loader", "isparta", "istanbul", "coverage" ],
+  "keywords": [
+    "webpack",
+    "loader",
+    "isparta",
+    "istanbul",
+    "coverage"
+  ],
   "homepage": "https://github.com/deepsweet/isparta-loader",
   "repository": "deepsweet/isparta-loader",
   "author": "Kir Belevich <kir@soulshine.in> (https://github.com/deepsweet)",
   "main": "index.js",
-  "files": [ "index.js" ],
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
     "isparta": "4.x.x",
     "loader-utils": "^0.2.16"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "index.js",
   "files": [ "index.js" ],
   "dependencies": {
-    "isparta": "4.x.x"
+    "isparta": "4.x.x",
+    "loader-utils": "^0.2.16"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
As of Webpack v2.1.0-beta.23 adding properties to the main config is disallowed. Loaders are required to receive their config via queries. This pull request also solves issue https://github.com/deepsweet/isparta-loader/issues/20.

Regards,
Riovir